### PR TITLE
Don't enforce changing core files in order to theme PB

### DIFF
--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/css/theme.css
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/css/theme.css
@@ -1,3 +1,0 @@
-:root{
-    --dnn-color-editbar-background: #0b1c24;
-}

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/scripts/bootstrap.js
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/scripts/bootstrap.js
@@ -26,10 +26,8 @@
     var version = (cdv ? '?cdv=' + cdv : '') + (debugMode ? '&t=' + Math.random(): '');
     var styles = [];
     var mainJs = mobi ? 'scripts/main.mobi.js' : 'scripts/main.js';
-    var themeCss = 'css/theme.css';
     var mainCss = mobi ? 'css/main.mobi.css' : 'css/main.css';
 
-    styles.push(themeCss);
     styles.push(mainCss);
 
     addCssToHead(styles, version);

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
@@ -6,8 +6,10 @@ namespace Dnn.PersonaBar.Library.Containers
 {
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using System.Threading;
     using System.Web;
+    using System.Web.Hosting;
     using System.Web.UI;
 
     using Dnn.PersonaBar.Library.Common;
@@ -18,7 +20,6 @@ namespace Dnn.PersonaBar.Library.Containers
     using DotNetNuke.Application;
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Entities.Users;
     using DotNetNuke.Services.Personalization;
     using Microsoft.Extensions.DependencyInjection;
     using Newtonsoft.Json.Linq;
@@ -119,6 +120,10 @@ namespace Dnn.PersonaBar.Library.Containers
             settings.Add("customModules", customModules);
 
             settings.Add("disableEditBar", Host.DisableEditBar);
+
+            var customThemePath = HostingEnvironment.MapPath(Path.Combine("Portals", "_default", "PersonaBarTheme.css"));
+            var customThemeExists = File.Exists(customThemePath);
+            settings.Add("theme", customThemeExists);
 
             return settings;
         }

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/theme.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/theme.css
@@ -7,4 +7,6 @@
     --dnn-color-pb-menu-text-highlight: #3c7a9a;
     
     --dnn-pb-menu-brand-background: url('../images/Logo.svg') no-repeat center center;
+
+    --dnn-color-editbar-background: #0b1c24;
 }

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/bootstrap.js
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/bootstrap.js
@@ -26,8 +26,15 @@
     var mainJs = 'scripts/main.js';
     var themeCss = 'css/theme.css';
     var mainCss = 'css/main.css';
+    var hasCustomTheme = editBarSettings['theme'];
 
-    styles.push(themeCss);
+    if (hasCustomTheme){
+        styles.push('../../../../Portals/_default/PersonaBarTheme.css');
+    }
+    else{
+        styles.push(themeCss);
+    }
+
     styles.push(mainCss);
     styles.push('css/graph.css');
 


### PR DESCRIPTION
Allows customizing the theme without modifying core files which is bad practice and hard to maintain for upgrades.